### PR TITLE
fixup! Handling Pausing from freezer state

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -769,13 +769,11 @@ func (c *linuxContainer) updateState(process parentProcess) error {
 
 func (c *linuxContainer) checkFreezer() (Status, error) {
 	path := c.cgroupManager.GetPaths()["freezer"]
-	if _, err := os.Stat(path); err != nil {
+	contents, err := ioutil.ReadFile(filepath.Join(path, "freezer.state"))
+	if err != nil {
 		if os.IsNotExist(err) {
 			return Running, nil
 		}
-	}
-	contents, err := ioutil.ReadFile(filepath.Join(path, "freezer.state"))
-	if err != nil {
 		return 0, newSystemError(err)
 	}
 	freezerstate := string(contents)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -768,7 +768,10 @@ func (c *linuxContainer) updateState(process parentProcess) error {
 }
 
 func (c *linuxContainer) checkFreezer() (Status, error) {
-	path := c.cgroupManager.GetPaths()["freezer"]
+	path, ok := c.cgroupManager.GetPaths()["freezer"]
+	if (!ok) {
+		return Running, nil
+	}
 	contents, err := ioutil.ReadFile(filepath.Join(path, "freezer.state"))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -767,6 +767,25 @@ func (c *linuxContainer) updateState(process parentProcess) error {
 	return json.NewEncoder(f).Encode(state)
 }
 
+func (c *linuxContainer) checkFreezer() (Status, error) {
+	path := c.cgroupManager.GetPaths()["freezer"]
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return Running, nil
+		}
+	}
+	contents, err := ioutil.ReadFile(filepath.Join(path, "freezer.state"))
+	if err != nil {
+		return 0, newSystemError(err)
+	}
+	freezerstate := string(contents)
+	if strings.TrimSpace(freezerstate) == "FROZEN" {
+		return Paused, nil
+	}
+	return Running, nil
+
+}
+
 func (c *linuxContainer) currentStatus() (Status, error) {
 	if _, err := os.Stat(filepath.Join(c.root, "checkpoint")); err == nil {
 		return Checkpointed, nil
@@ -781,10 +800,7 @@ func (c *linuxContainer) currentStatus() (Status, error) {
 		}
 		return 0, newSystemError(err)
 	}
-	if c.config.Cgroups != nil && c.config.Cgroups.Freezer == configs.Frozen {
-		return Paused, nil
-	}
-	return Running, nil
+	return c.checkFreezer()
 }
 
 func (c *linuxContainer) currentState() (*State, error) {


### PR DESCRIPTION
Avoid a racy Stat call (the filesystem could be removed after the Stat
but before the ReadFile).

Signed-off-by: W. Trevor King wking@tremily.us
